### PR TITLE
[Fix] Client i18n rendering

### DIFF
--- a/public/locales/de/leaderboard.json
+++ b/public/locales/de/leaderboard.json
@@ -1,0 +1,3 @@
+{
+  "title": "🇩🇪 Leaderhausen"
+}

--- a/public/locales/de/navigation.json
+++ b/public/locales/de/navigation.json
@@ -1,13 +1,13 @@
 {
-  "title": "S33DS",
-  "stake": "Stake",
-  "mint": "Mint",
-  "donate": "Donate",
-  "leaderboard": "Leaderboard",
-  "about": "About",
-  "connect": "Connect",
-  "english": "English",
-  "german": "German",
-  "french": "French",
-  "spanish": "Spanish"
+  "title": "Saat",
+  "stake": "Anteil",
+  "mint": "Münze",
+  "donate": "Spenden",
+  "leaderboard": "Bestenliste",
+  "about": "Über",
+  "connect": "Anschließen",
+  "english": "Englisch",
+  "german": "Deutsch",
+  "french": "Französisch",
+  "spanish": "Spanisch"
 }

--- a/public/locales/en/leaderboard.json
+++ b/public/locales/en/leaderboard.json
@@ -1,0 +1,3 @@
+{
+  "title": "Leaderboard"
+}

--- a/public/locales/es/leaderboard.json
+++ b/public/locales/es/leaderboard.json
@@ -1,0 +1,3 @@
+{
+  "title": "🇪🇸 Leaderboardo"
+}

--- a/public/locales/es/navigation.json
+++ b/public/locales/es/navigation.json
@@ -1,0 +1,13 @@
+{
+  "title": "S33DS",
+  "stake": "Stake",
+  "mint": "Mint",
+  "donate": "Donate",
+  "leaderboard": "Leaderboard",
+  "about": "About",
+  "connect": "Connect",
+  "english": "English",
+  "german": "German",
+  "french": "French",
+  "spanish": "Spanish"
+}

--- a/public/locales/es/navigation.json
+++ b/public/locales/es/navigation.json
@@ -1,13 +1,13 @@
 {
-  "title": "S33DS",
-  "stake": "Stake",
-  "mint": "Mint",
-  "donate": "Donate",
-  "leaderboard": "Leaderboard",
-  "about": "About",
-  "connect": "Connect",
-  "english": "English",
-  "german": "German",
-  "french": "French",
-  "spanish": "Spanish"
+  "title": "Semillas",
+  "stake": "Apostar",
+  "mint": "Acuñar",
+  "donate": "Donar",
+  "leaderboard": "Clasificación",
+  "about": "Sobre",
+  "connect": "Conectar",
+  "english": "Inglés",
+  "german": "Alemán",
+  "french": "Francés",
+  "spanish": "Español"
 }

--- a/public/locales/fr/leaderboard.json
+++ b/public/locales/fr/leaderboard.json
@@ -1,0 +1,3 @@
+{
+  "title": "Classement"
+}

--- a/public/locales/fr/navigation.json
+++ b/public/locales/fr/navigation.json
@@ -1,0 +1,13 @@
+{
+  "title": "S33DS",
+  "stake": "Stake",
+  "mint": "Mint",
+  "donate": "Donate",
+  "leaderboard": "Leaderboard",
+  "about": "About",
+  "connect": "Connect",
+  "english": "English",
+  "german": "German",
+  "french": "French",
+  "spanish": "Spanish"
+}

--- a/public/locales/fr/navigation.json
+++ b/public/locales/fr/navigation.json
@@ -1,13 +1,13 @@
 {
-  "title": "S33DS",
-  "stake": "Stake",
-  "mint": "Mint",
-  "donate": "Donate",
-  "leaderboard": "Leaderboard",
-  "about": "About",
-  "connect": "Connect",
-  "english": "English",
-  "german": "German",
-  "french": "French",
-  "spanish": "Spanish"
+  "title": "Des graines",
+  "stake": "Tuteurer",
+  "mint": "Monnayer",
+  "donate": "Faire un don",
+  "leaderboard": "Classement",
+  "about": "Sur",
+  "connect": "Relier",
+  "english": "Anglais",
+  "german": "Allemand",
+  "french": "Français",
+  "spanish": "Espagnole"
 }

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,7 +1,20 @@
 /* eslint-disable @next/next/no-img-element */
 import { useRouter } from 'next/router'
 import NextLink from 'next/link'
-import { useTranslation } from 'next-i18next'
+
+import { useTranslation } from '../../utils/use-translation'
+
+const germanTrans = require('../../../public/locales/de/navigation.json')
+const englishTrans = require('../../../public/locales/en/navigation.json')
+const spanishTrans = require('../../../public/locales/es/navigation.json')
+const frenchTrans = require('../../../public/locales/fr/navigation.json')
+
+const localisation = {
+  de: germanTrans,
+  en: englishTrans,
+  es: spanishTrans,
+  fr: frenchTrans
+}
 
 import { Box, Flex, HStack, Stack, Text } from '@chakra-ui/layout'
 import {
@@ -40,27 +53,31 @@ export const Header = () => {
   const { isOpen, onOpen, onClose } = useDisclosure()
 
   const { locale } = useRouter()
-  const { t } = useTranslation('navigation')
+  const translate = useTranslation(localisation)
 
   const navItems = [
-    { text: t('stake'), href: '/stake', icon: <KeyIcon className="h-6 w-6" /> },
     {
-      text: t('mint'),
+      text: translate('stake'),
+      href: '/stake',
+      icon: <KeyIcon className="h-6 w-6" />
+    },
+    {
+      text: translate('mint'),
       href: '/mint',
       icon: <PlusCircleIcon className="h-6 w-6" />
     },
     {
-      text: t('donate'),
+      text: translate('donate'),
       href: '/donate',
       icon: <HeartIcon className="h-6 w-6" />
     },
     {
-      text: t('leaderboard'),
+      text: translate('leaderboard'),
       href: '/leaderboard',
       icon: <FireIcon className="h-6 w-6" />
     },
     {
-      text: t('about'),
+      text: translate('about'),
       href: '/about',
       icon: <InformationCircleIcon className="h-6 w-6" />
     }
@@ -125,7 +142,7 @@ export const Header = () => {
                     passHref
                     locale={locale === 'en' ? 'de' : 'en'}
                   >
-                    <Text className="capitalize">{t('english')}</Text>
+                    <Text className="capitalize">{translate('english')}</Text>
                   </NextLink>
                 </MenuItem>
                 <MenuItem>
@@ -134,7 +151,7 @@ export const Header = () => {
                     passHref
                     locale={locale === 'fr' ? 'en' : 'fr'}
                   >
-                    <Text className="capitalize">{t('french')}</Text>
+                    <Text className="capitalize">{translate('french')}</Text>
                   </NextLink>
                 </MenuItem>
                 <MenuItem>
@@ -143,7 +160,7 @@ export const Header = () => {
                     passHref
                     locale={locale === 'de' ? 'en' : 'de'}
                   >
-                    <Text className="capitalize">{t('german')}</Text>
+                    <Text className="capitalize">{translate('german')}</Text>
                   </NextLink>
                 </MenuItem>
                 <MenuItem>
@@ -152,7 +169,7 @@ export const Header = () => {
                     passHref
                     locale={locale === 'es' ? 'en' : 'es'}
                   >
-                    <Text className="capitalize">{t('spanish')}</Text>
+                    <Text className="capitalize">{translate('spanish')}</Text>
                   </NextLink>
                 </MenuItem>
               </MenuList>
@@ -168,7 +185,7 @@ export const Header = () => {
                 </>
               ) : (
                 <>
-                  <Text className="capitalize">{t('connect')}</Text>
+                  <Text className="capitalize">{translate('connect')}</Text>
                   <LoginIcon className="w-5 h-5" />
                 </>
               )}

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -3,10 +3,24 @@ import type { NextPage } from 'next'
 import { Heading, Flex, Text, Box } from '@chakra-ui/layout'
 import { Image } from '@chakra-ui/react'
 
-import { useTranslation } from 'next-i18next'
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+// import { useTranslation } from 'next-i18next'
+// import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { useTranslation } from '../utils/use-translation'
+
+const germanTrans = require('../../public/locales/de/about.json')
+const englishTrans = require('../../public/locales/en/about.json')
+const spanishTrans = require('../../public/locales/es/about.json')
+const frenchTrans = require('../../public/locales/fr/about.json')
+
+const localisation = {
+  de: germanTrans,
+  en: englishTrans,
+  es: spanishTrans,
+  fr: frenchTrans
+}
 
 const About: NextPage = () => {
+  console.log('<<', germanTrans)
   return (
     <Flex
       direction="row"
@@ -42,16 +56,11 @@ const About: NextPage = () => {
   )
 }
 
-type LocaleType = 'de' | 'en' | 'es' | 'fr'
-interface LocaleTypeProps {
-  locale: LocaleType
-}
-
-export const getStaticProps = async ({ locale }: LocaleTypeProps) => ({
-  props: {
-    ...(await serverSideTranslations(locale, ['about']))
-  }
-})
+// export const getStaticProps = async ({ locale }: LocaleTypeProps) => ({
+//   props: {
+//     ...(await serverSideTranslations(locale, ['about', 'navigation']))
+//   }
+// })
 
 export default About
 
@@ -64,7 +73,7 @@ const Paragraph = ({
   paragraph1: string
   paragraph2?: string
 }) => {
-  const { t } = useTranslation('about')
+  const translate = useTranslation(localisation)
 
   return (
     <Box
@@ -73,7 +82,7 @@ const Paragraph = ({
       }
     >
       <Heading color="#fff" fontWeight="bold" fontSize="6vh">
-        {t(header)}
+        {translate(header)}
       </Heading>
       <Flex
         direction="column"
@@ -83,11 +92,11 @@ const Paragraph = ({
         justifyContent="space-around"
       >
         <Text color="#fff" fontWeight={400} fontSize="2vh">
-          {t(paragraph1)}
+          {translate(paragraph1)}
         </Text>
         {paragraph2 ? (
           <Text color="#fff" fontWeight={400} fontSize="2vh">
-            {t(paragraph2)}
+            {translate(paragraph2)}
           </Text>
         ) : null}
       </Flex>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,15 +4,26 @@ import NextLink from 'next/link'
 
 import { useEffect } from 'react'
 
-import { useTranslation } from 'next-i18next'
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { useTranslation } from '../utils/use-translation'
+
+const germanTrans = require('../../public/locales/de/about.json')
+const englishTrans = require('../../public/locales/en/about.json')
+const spanishTrans = require('../../public/locales/es/about.json')
+const frenchTrans = require('../../public/locales/fr/about.json')
+
+const localisation = {
+  de: germanTrans,
+  en: englishTrans,
+  es: spanishTrans,
+  fr: frenchTrans
+}
 
 import { Button } from '@chakra-ui/button'
 import { Heading, Flex, Text } from '@chakra-ui/layout'
 import { confetti, blastConfetti } from '../utils/confetti'
 
 const Home: NextPage = () => {
-  const { t } = useTranslation('common')
+  const translate = useTranslation(localisation)
 
   useEffect(() => {
     /**
@@ -49,7 +60,7 @@ const Home: NextPage = () => {
     >
       <Flex direction="column" alignItems="center" textAlign="center">
         <Heading fontSize={['1.4em', '1.7em', '2.1em']}>
-          {t('homepage-title')}{' '}
+          {translate('homepage-title')}{' '}
           <Text display="inline" color="ukraineYellow">
             Ukraine
           </Text>
@@ -62,7 +73,7 @@ const Home: NextPage = () => {
             fontSize={['1.3em', '1.8em', '2em']}
           >
             {' '}
-            {t('donated')}
+            {translate('donated')}
           </Text>
         </Flex>
         <Text
@@ -87,7 +98,7 @@ const Home: NextPage = () => {
               bg: 'darkYellow'
             }}
           >
-            {t('stake')}
+            {translate('stake')}
           </Button>
         </NextLink>
         <NextLink href="/donate" passHref>
@@ -104,7 +115,7 @@ const Home: NextPage = () => {
               bg: '#DDD'
             }}
           >
-            {t('donate')}
+            {translate('donate')}
           </Button>
         </NextLink>
       </Flex>
@@ -128,11 +139,5 @@ const Home: NextPage = () => {
     </Flex>
   )
 }
-
-export const getStaticProps = async ({ locale }: LocaleTypeProps) => ({
-  props: {
-    ...(await serverSideTranslations(locale, ['common']))
-  }
-})
 
 export default Home

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -129,11 +129,6 @@ const Home: NextPage = () => {
   )
 }
 
-type LocaleType = 'de' | 'en' | 'es' | 'fr'
-interface LocaleTypeProps {
-  locale: LocaleType
-}
-
 export const getStaticProps = async ({ locale }: LocaleTypeProps) => ({
   props: {
     ...(await serverSideTranslations(locale, ['common']))

--- a/src/pages/leaderboard.tsx
+++ b/src/pages/leaderboard.tsx
@@ -22,13 +22,16 @@ import { shorten } from '../utils/shorten'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
 import { DuplicateIcon } from '@heroicons/react/outline'
 
+const germanTrans = require('../../public/locales/de/leaderboard.json')
+const englishTrans = require('../../public/locales/en/leaderboard.json')
+const spanishTrans = require('../../public/locales/es/leaderboard.json')
+const frenchTrans = require('../../public/locales/fr/leaderboard.json')
+
 const localisation = {
-  en: {
-    title: 'Leaderboard'
-  },
-  fr: {
-    title: 'Classement'
-  }
+  de: germanTrans,
+  en: englishTrans,
+  es: spanishTrans,
+  fr: frenchTrans
 }
 
 const RECEIVER_WALLET = '0x10E1439455BD2624878b243819E31CfEE9eb721C'

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,5 @@
+type LocaleType = 'de' | 'en' | 'es' | 'fr'
+
+interface LocaleTypeProps {
+  locale: LocaleType
+}


### PR DESCRIPTION
This should also prevent the /about and homepage from resetting the wallet connect. 
server side rendering of the translations breaks this, but speeds up when generating SSR pages.